### PR TITLE
21 repair discrod reminder

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           severity: info
           username: Github Actions Reminder
-          text: @takashitanaka_kccs @binnmti @harineko0  It starts in an hour.
+          text: It starts in an hour! @takashitanaka_kccs @binnmti @harineko0
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -2,8 +2,8 @@ name: schedule_reminder
 
 on:
   schedule:
-    # Thursday 22:00 JST
-    - cron: "* 13 * * 5"
+    # Friday 21:00 JST
+    - cron: "0 12 * * 5"
 
 jobs:
   send_reminder:
@@ -13,6 +13,6 @@ jobs:
         uses: rjstone/discord-webhook-notify@v1
         with:
           severity: info
-          details: Auto Reminder
-          text: Regular meeting tomorrow at 10pm.
+          username: Github Actions Reminder
+          text: @takashitanaka_kccs @binnmti @harineko0  It starts in an hour.
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}

--- a/one-pager-maker/src/tests/e2e/example.spec.ts
+++ b/one-pager-maker/src/tests/e2e/example.spec.ts
@@ -4,7 +4,7 @@ test('has title', async ({ page }) => {
   await page.goto('https://one-pager-maker.web.app/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle('Vite + React + TS');
+  await expect(page).toHaveTitle('Vite + React + TS 2');
 });
 
 // test('get started link', async ({ page }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the scheduled reminder timing in GitHub Actions to trigger on Friday at 21:00 JST, with an improved reminder message for meetings.
- **Tests**
	- Adjusted an end-to-end test assertion to reflect the updated project title format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->