### PR TITLE
Fix deployment github action failure

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,19 +16,32 @@ jobs:
     concurrency: production
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          npm ci
-          npm install -g firebase-tools
-          npm run build
-
+      - uses: oven-sh/setup-bun@v1
+      - name: cache-node-modules
+        uses: actions/cache@v3
+        id: cache-bun
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: bun install
+        if: ${{ steps.cache-bun.outputs.cache-hit != 'true' }}
+        run: bun i
+      - name: install firebase-tools
+        run: bun i -g firebase-tools
+      - name: bun run build
+        run: bun run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ONE_PAGER_MAKER }}"
           channelId: live
           projectId: one-pager-maker
-
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,9 +24,9 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-build-cache-bun-${{ hashFiles('**/bun.lockb') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-cache-bun-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: bun install


### PR DESCRIPTION
## Summary
* Change to use bun, not npm
* Add cachIng node_modules
* Add bun rum build. This might be unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Optimized deployment workflow by updating setup actions and caching strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->