### PR TITLE
Add Status and UrlPrivilege type to documentType.ts.

### DIFF
--- a/one-pager-maker/src/redux/document/documentType.ts
+++ b/one-pager-maker/src/redux/document/documentType.ts
@@ -29,6 +29,7 @@ export type DocumentForUpdate = Partial<Omit<Document, "updated_at">> & {
 export type Status = z.infer<typeof statusSchema>;
 export const statusValues = Object.values(statusSchema.enum);
 export type UrlPrivilege = z.infer<typeof privilegeSchema>;
+export const urlPrivilegeValues = Object.values(privilegeSchema.enum);
 
 export const documentConverter: FirestoreDataConverter<Document> = {
     fromFirestore(snapshot): Document {

--- a/one-pager-maker/src/redux/document/documentType.ts
+++ b/one-pager-maker/src/redux/document/documentType.ts
@@ -2,6 +2,8 @@ import {FirestoreDataConverter, Timestamp} from 'firebase/firestore';
 import {z} from "zod";
 import {assertZodSchema} from "../../utils/asserts.ts";
 
+const statusSchema = z.enum(['draft', 'reviewed', 'final', 'obsolete']);
+const privilegeSchema = z.enum(['private', 'can_view', 'can_edit']);
 /**
  * Firestore の Document 型のスキーマ
  */
@@ -9,11 +11,11 @@ const documentSchema = z.object({
     id: z.string(),
     title: z.string(),
     contents: z.string(),
-    status: z.enum(['draft', 'reviewed', 'final', 'obsolete']),
+    status: statusSchema,
     owner_id: z.string(),
     contributors: z.array(z.string()),
     reviewers: z.array(z.string()),
-    url_privilege: z.enum(['private', 'can_view', 'can_edit']),
+    url_privilege: privilegeSchema,
     deleted_at: z.instanceof(Timestamp).nullable(),
     updated_at: z.instanceof(Timestamp),
     created_at: z.instanceof(Timestamp)
@@ -24,6 +26,8 @@ export type DocumentForCreate = Omit<Document, "id" | "deleted_at" | "updated_at
 export type DocumentForUpdate = Partial<Omit<Document, "updated_at">> & {
     id: string
 }
+export type Status = z.infer<typeof statusSchema>;
+export type UrlPrivilege = z.infer<typeof privilegeSchema>;
 
 export const documentConverter: FirestoreDataConverter<Document> = {
     fromFirestore(snapshot): Document {

--- a/one-pager-maker/src/redux/document/documentType.ts
+++ b/one-pager-maker/src/redux/document/documentType.ts
@@ -27,6 +27,7 @@ export type DocumentForUpdate = Partial<Omit<Document, "updated_at">> & {
     id: string
 }
 export type Status = z.infer<typeof statusSchema>;
+export const statusValues = Object.keys(statusSchema.enum);
 export type UrlPrivilege = z.infer<typeof privilegeSchema>;
 
 export const documentConverter: FirestoreDataConverter<Document> = {

--- a/one-pager-maker/src/redux/document/documentType.ts
+++ b/one-pager-maker/src/redux/document/documentType.ts
@@ -27,7 +27,7 @@ export type DocumentForUpdate = Partial<Omit<Document, "updated_at">> & {
     id: string
 }
 export type Status = z.infer<typeof statusSchema>;
-export const statusValues = Object.keys(statusSchema.enum);
+export const statusValues = Object.values(statusSchema.enum) as Status[];
 export type UrlPrivilege = z.infer<typeof privilegeSchema>;
 
 export const documentConverter: FirestoreDataConverter<Document> = {

--- a/one-pager-maker/src/redux/document/documentType.ts
+++ b/one-pager-maker/src/redux/document/documentType.ts
@@ -27,7 +27,7 @@ export type DocumentForUpdate = Partial<Omit<Document, "updated_at">> & {
     id: string
 }
 export type Status = z.infer<typeof statusSchema>;
-export const statusValues = Object.values(statusSchema.enum) as Status[];
+export const statusValues = Object.values(statusSchema.enum);
 export type UrlPrivilege = z.infer<typeof privilegeSchema>;
 
 export const documentConverter: FirestoreDataConverter<Document> = {


### PR DESCRIPTION
# Summary
* Added Status type (`'draft' | 'reviewed' | 'final' | 'obsolete'`)
* Added UrlPrivilege type (`'private' | 'can_view' | 'can_edit'`)
* Added statusValues, which equals to an array like `["draft" | "reviewed" | "final" | "obsolete"]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Improved type safety and clarity in document management by refactoring the document type schema in the Redux store to use Zod enums for `status` and `url_privilege` fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->