### PR TITLE
Fix userRepositoryImpl.ts wrong user id error

### DIFF
--- a/one-pager-maker/src/repository/userRepositoryImpl.ts
+++ b/one-pager-maker/src/repository/userRepositoryImpl.ts
@@ -14,12 +14,12 @@ export class UserRepositoryImpl implements UserRepository {
     private readonly colRef = () => collection(db, `users`)
         .withConverter(userConverter);
 
-    private readonly docRef = (uid: string) => doc(db, `users/${uid}`)
+    private readonly docRef = (id: string) => doc(db, `users/${id}`)
         .withConverter(userConverter);
 
     async create(user: ForCreateWithId<User>): Promise<User> {
         try {
-            const ref = doc(this.colRef());
+            const ref = this.docRef(user.id);
             const data: WithTimestamp<Omit<User, 'id'>> = {
                 ...user,
                 created_at: serverTimestamp(),

--- a/one-pager-maker/tests/integration/repository/userRepositoryImpl.test.ts
+++ b/one-pager-maker/tests/integration/repository/userRepositoryImpl.test.ts
@@ -1,0 +1,27 @@
+import {beforeAll, beforeEach, describe, test, expect} from "vitest";
+import {UserRepositoryImpl} from "../../../src/repository/userRepositoryImpl";
+import {
+    deleteFirestoreEmulatorData,
+    useFirestoreEmulator
+} from "../firebaseEmulatorUtils";
+import {userFactory} from "../../_shared/factory/userFactory";
+
+describe("UserRepositoryImpl Test", () => {
+    const repository = new UserRepositoryImpl();
+
+    beforeAll(() => useFirestoreEmulator());
+
+    beforeEach(() => deleteFirestoreEmulatorData());
+
+    describe('create()', function () {
+        test("returns correct data", async () => {
+            const id = 'test';
+            await repository.create(userFactory.build({
+                id,
+            }));
+            const result = await repository.findUnique(id);
+            expect(result).not.toBeUndefined();
+            expect(result).toHaveProperty('id', id);
+        })
+    });
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user document creation by updating internal references to use `id` instead of `uid`.

- **Tests**
  - Added integration tests for user creation functionality to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->