### PR TITLE
fix: Preserve user input in Edit component when switching tabs

### DIFF
--- a/one-pager-maker/src/pages/Edit.tsx
+++ b/one-pager-maker/src/pages/Edit.tsx
@@ -78,7 +78,7 @@ function Edit() {
         uid,
         document: documentData
       });
-      
+
       setDocumentData(result);
 
       // 更新したときに閲覧履歴を設定

--- a/one-pager-maker/src/pages/Edit.tsx
+++ b/one-pager-maker/src/pages/Edit.tsx
@@ -33,9 +33,10 @@ function Edit() {
   const reviewHistoryMutation = viewHistoryApi.useSetReviewHistoryMutation();
 
   useEffect(() => {
-    if (document === undefined) return;
-    setDocumentData(document);
-  }, [document]);
+    if (documentResult.data?.value && !documentData) {
+      setDocumentData(documentResult.data.value);
+    }
+  }, [documentResult.data, documentData]);
 
   const updateDocumentState = <K extends keyof Document>(
     key: K,
@@ -77,6 +78,8 @@ function Edit() {
         uid,
         document: documentData
       });
+      
+      setDocumentData(result);
 
       // 更新したときに閲覧履歴を設定
       const mutationArgs = {

--- a/one-pager-maker/src/pages/Edit.tsx
+++ b/one-pager-maker/src/pages/Edit.tsx
@@ -33,10 +33,10 @@ function Edit() {
   const reviewHistoryMutation = viewHistoryApi.useSetReviewHistoryMutation();
 
   useEffect(() => {
-    if (documentResult.data?.value && !documentData) {
-      setDocumentData(documentResult.data.value);
+    if (document && !documentData) {
+      setDocumentData(document);
     }
-  }, [documentResult.data, documentData]);
+  }, [document, documentData]);
 
   const updateDocumentState = <K extends keyof Document>(
     key: K,


### PR DESCRIPTION
## Description
- Changed condition of useEffect based on documentResult.

`document === undefined` -> `documentResult.data?.value && !documentData`

- Added setDocumentData after the save to reflect Server state


## Test

https://github.com/user-attachments/assets/af2232e9-51fe-4b5e-b69e-ec7b45cf077a





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved logic for document data management based on API responses, ensuring state updates only occur with valid data.
- **Bug Fixes**
	- Enhanced control flow to prevent unnecessary updates, ensuring the component accurately reflects the latest document changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->